### PR TITLE
Add daily security scanning workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  # Keep GitHub Actions up to date
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    # Group minor/patch updates into a single PR to reduce noise
+    groups:
+      actions-minor:
+        update-types:
+          - "minor"
+          - "patch"

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -1,0 +1,137 @@
+name: Security Scan
+
+# Daily security scan for dependencies, container images, secrets, and misconfigurations
+# using Trivy. Results uploaded to GitHub Security tab via SARIF.
+#
+# Note: CodeQL also runs on this repo via a broadinstitute org-level rule
+# (outside our control). This workflow focuses on dependency CVEs and
+# infrastructure scanning.
+
+on:
+  schedule:
+    # Daily at 3 AM UTC (early morning CET/CEST for primary developer timezone)
+    - cron: '0 3 * * *'
+  workflow_dispatch: {}
+  push:
+    branches: [main]
+    paths:
+      - 'conanfile.txt'
+      - '.gitmodules'
+      - 'CMakeLists.txt'
+      - 'Dockerfile.ci'
+      - '.trivyignore'
+      - '.trivy-ignore-policy.rego'
+      - '.github/workflows/security-scan.yml'
+
+permissions:
+  contents: read
+
+env:
+  CONAN_VERSION: '2.8.1'
+
+jobs:
+  # Primary scan: filesystem for dependency CVEs, secrets, and misconfigurations
+  filesystem-scan:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write    # Required for SARIF upload
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      # Generate conan.lock for Trivy's C++ dependency scanner
+      # Delphy doesn't commit conan.lock, so we generate it here
+      - name: Generate Conan lockfile for vulnerability scanning
+        run: |
+          pip install 'conan==${{ env.CONAN_VERSION }}'
+          conan profile detect --force
+          conan lock create .
+
+      - name: Run Trivy filesystem scan (vulnerabilities + secrets)
+        # Pinned to commit SHA due to March 2026 supply chain compromise
+        # (all version tags were force-pushed to malicious commits).
+        # SHA ed142fd0673e97e23eac54620cfb913e5ce36c25 is vetted v0.36.0.
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          scan-type: 'fs'
+          scan-ref: '.'
+          scanners: 'vuln,secret'
+          format: 'sarif'
+          output: 'trivy-fs-results.sarif'
+          severity: 'CRITICAL,HIGH'
+          limit-severities-for-sarif: true
+          trivyignores: '.trivyignore'
+          ignore-policy: '.trivy-ignore-policy.rego'
+
+      - name: Run Trivy misconfiguration scan
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          scan-type: 'fs'
+          scan-ref: '.'
+          scanners: 'misconfig'
+          format: 'sarif'
+          output: 'trivy-misconfig-results.sarif'
+          severity: 'CRITICAL,HIGH'
+          limit-severities-for-sarif: true
+          trivyignores: '.trivyignore'
+          ignore-policy: '.trivy-ignore-policy.rego'
+
+      - name: Upload vulnerability/secret results to GitHub Security
+        uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
+        if: always()
+        with:
+          sarif_file: 'trivy-fs-results.sarif'
+          category: 'trivy-filesystem-vuln'
+
+      - name: Upload misconfiguration results to GitHub Security
+        uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
+        if: always()
+        with:
+          sarif_file: 'trivy-misconfig-results.sarif'
+          category: 'trivy-filesystem-misconfig'
+
+  # Secondary scan: container image for Alpine OS-level CVEs
+  container-scan:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read              # Required to pull from GHCR
+      security-events: write      # Required for SARIF upload
+
+    steps:
+      - name: Checkout (for .trivyignore and .trivy-ignore-policy.rego)
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: |
+            .trivyignore
+            .trivy-ignore-policy.rego
+          sparse-checkout-cone-mode: false
+
+      - name: Run Trivy container image scan
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          scan-type: 'image'
+          image-ref: 'ghcr.io/broadinstitute/delphy:latest'
+          scanners: 'vuln'
+          format: 'sarif'
+          output: 'trivy-image-results.sarif'
+          severity: 'CRITICAL,HIGH'
+          limit-severities-for-sarif: true
+          trivyignores: '.trivyignore'
+          ignore-policy: '.trivy-ignore-policy.rego'
+
+      - name: Upload container scan results to GitHub Security
+        uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
+        if: always()
+        with:
+          sarif_file: 'trivy-image-results.sarif'
+          category: 'trivy-container-image'

--- a/.trivy-ignore-policy.rego
+++ b/.trivy-ignore-policy.rego
@@ -1,0 +1,45 @@
+#
+# .trivy-ignore-policy.rego
+#
+# Rego policy for class-based CVE filtering in Trivy security scans.
+# This is a skeleton/no-op policy that can be filled in later if scan
+# noise requires systematic filtering.
+#
+# CONTEXT:
+#   Delphy is a C++20 Bayesian phylogenetics tool that:
+#   - Runs as a command-line tool (no network listeners, no web UI)
+#   - Processes genomic data files (FASTA, DPHY format)
+#   - Is distributed both as native binaries and Docker containers
+#   - Uses dependencies from Conan (boost, eigen, ms-gsl), git submodules
+#     (abseil, flatbuffers, ctpl, cxxopts), and vendored headers (cppcoro)
+#
+# USAGE:
+#   The security-scan.yml workflow automatically passes this policy to
+#   Trivy via --ignore-policy. You do not need to manually specify it.
+#
+# TO ADD FILTERS:
+#   Uncomment and modify the example rules below, or add new ones.
+#   Common patterns for bioinformatics/computational tools:
+#   - Filter CVEs requiring physical access (AV:P)
+#   - Filter CVEs requiring adjacent network access (AV:A)
+#   - Filter CVEs requiring local + user interaction (AV:L + UI:R)
+#   - Filter CVEs with availability-only impact (C:N + I:N)
+#
+# CVSS VERSION SUPPORT:
+#   Rules should handle both CVSS v3.1 and v4.0 vector strings since
+#   Trivy is transitioning to v4.0 for newer advisories.
+#
+# LAST REVIEWED: 2026-05-22
+# REVIEW CADENCE: As needed when false positives accumulate
+
+package trivy
+
+default ignore = false
+
+# Example rule (currently disabled - uncomment and modify as needed):
+#
+# ignore {
+#   # Physical access required (AV:P) - cloud-hosted binaries are never physically accessible
+#   input.CVSS != null
+#   contains(input.CVSS, "AV:P")
+# }

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,12 @@
+# .trivyignore - CVE exceptions for Trivy security scanning
+#
+# Add CVE IDs (one per line) to suppress known false positives or
+# accepted risks. Each entry should include a comment explaining why
+# it's safe to ignore.
+#
+# Format:
+#   # Reason for ignoring
+#   CVE-YYYY-NNNNN
+#
+# Review this file periodically to remove entries for CVEs that have
+# been fixed upstream.


### PR DESCRIPTION
## Summary

Adds a scheduled daily Trivy security scan workflow covering:
- **Filesystem scan** (primary): Scans Conan dependencies, secrets, and Docker/workflow misconfigurations
- **Container image scan** (secondary): Scans the published GHCR Docker image for Alpine OS-level CVEs

Both scans upload results to the GitHub Security tab via SARIF.

## Details

- **Schedule**: Daily at 3 AM UTC (CET/CEST-friendly timing)
- **Triggers**: Also runs on manual dispatch and pushes to main that change dependency/security files
- **Severity filter**: `CRITICAL,HIGH` only
- **Action pinning**: Trivy and CodeQL actions pinned to full SHAs due to Trivy's March 2026 supply chain compromise
- **Filtering**: Both `.trivyignore` (per-CVE) and `.trivy-ignore-policy.rego` (class-based) wired in (currently empty/no-op)
- **Dependabot**: Added for GitHub Actions updates

## Rationale

Unlike viral-ngs (where the Docker container is the primary artifact), Delphy is often run as uncontainerized native binaries. Filesystem scanning catches dependency CVEs that affect all distribution modes, not just container users.

## Test plan

After merge:
- [ ] Manually trigger via workflow_dispatch
- [ ] Verify both `filesystem-scan` and `container-scan` jobs complete
- [ ] Check Security > Code scanning alerts tab for SARIF results
- [ ] Review findings and add false positives to `.trivyignore` as needed