### PR TITLE
Group all dependabot updates into a single PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,9 +5,14 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    # Group minor/patch updates into a single PR to reduce noise
+    # Group all updates (including major) into a single PR to reduce noise
     groups:
-      actions-minor:
+      all-actions:
         update-types:
+          - "major"
           - "minor"
           - "patch"
+    # Leave SHA-pinned third-party actions alone
+    ignore:
+      - dependency-name: "aquasecurity/trivy-action"
+      - dependency-name: "github/codeql-action"


### PR DESCRIPTION
## Summary

- Include `major` version bumps in the dependabot grouping alongside `minor` and `patch`, so dependabot opens one combined PR per week instead of one per action
- Ignore SHA-pinned third-party actions (`aquasecurity/trivy-action`, `github/codeql-action`) to preserve intentional pinning from PR #11

## Follow-up

After merging, close the 5 existing individual dependabot PRs (#12–#16) so dependabot can re-open a single grouped PR on its next run.

## Test plan

- [ ] Merge and wait for next weekly dependabot run
- [ ] Verify it opens at most one grouped PR
- [ ] Verify trivy-action and codeql-action are not included